### PR TITLE
Allow multiple groupings of messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ config :gtfs_realtime_viz, :max_archive, 5
 
 This app runs a GenServer that stores protobuf data sent to it, and which can render the messages its received as HTML. Whether running standalone or within another application, the interface for interacting with the tool is the `GTFSRealtimeViz` module.
 
-First you send raw protobuf data to it with `GTFSRealtimeViz.new_message/2`. The first argument is the protobuf data, and the second is a comment about that file. For example, if you have the data saved locally in a file, you might do:
+First you send raw protobuf data to it with `GTFSRealtimeViz.new_message/3`. The first argument specifies what type of data it is, if you want to send data, say, from multiple environments. The second argument is the protobuf data, and the third is a comment about that data. For example, if you have the data saved locally in a file, you might do:
 
 ```ex
-iex> GTFSRealtimeViz.new_message(File.read!("/path/to/file.pb"), "This is my PB file")
+iex> GTFSRealtimeViz.new_message(:prod, File.read!("/path/to/file.pb"), "This is my PB file")
 ```
 
 Note that a GTFS Realtime message can have Vehicle Positions, Trip Updates, or Alerts. This tool currently only uses Vehicle Positions and will ignore anything else it's sent.
 
-As you send multiple messages to the app, it will store them all, up to the configured `max_archive`, at which point it will evict older messages.
+As you send multiple messages to the app, it will store them all, up to the configured `max_archive` per grouping, at which point it will evict older messages.
 
-To generate HTML, run `GTFSRealtimeViz.visualize/0`. This will return a `String.t` of HTML. It's just a fragment (e.g., it lacks `<html>` tags and the like), but if you save it and open it in a browser, most browsers should display it just fine. Alternatively, if you're using this in another application, because it's just a fragment, you should be able to render the string within the frame of the other application.
+To generate HTML, run `GTFSRealtimeViz.visualize/1`. This will return a `String.t` of HTML. It's just a fragment (e.g., it lacks `<html>` tags and the like), but if you save it and open it in a browser, most browsers should display it just fine. Alternatively, if you're using this in another application, because it's just a fragment, you should be able to render the string within the frame of the other application.
 
 If you just want a standalone file to open in a browser, you might run:
 
 ```ex
-iex> File.write!("/path/to/file.html", GTFSRealtimeViz.visualize())
+iex> File.write!("/path/to/file.html", GTFSRealtimeViz.visualize(:prod))
 ```

--- a/lib/gtfs_realtime_viz.ex
+++ b/lib/gtfs_realtime_viz.ex
@@ -15,21 +15,21 @@ defmodule GTFSRealtimeViz do
 
   @routes Application.get_env(:gtfs_realtime_viz, :routes)
 
-  @spec new_message(Proto.raw, String.t) :: :ok
-  def new_message(raw, comment) do
-    State.new_data(raw, comment)
+  @spec new_message(term, Proto.raw, String.t) :: :ok
+  def new_message(group, raw, comment) do
+    State.new_data(group, raw, comment)
   end
 
-  @spec visualize() :: String.t
-  def visualize do
-    [vehicle_archive: vehicles_by_stop_id(), routes: @routes]
+  @spec visualize(term) :: String.t
+  def visualize(group) do
+    [vehicle_archive: vehicles_by_stop_id(group), routes: @routes]
     |> gen_html
     |> Phoenix.HTML.safe_to_string
   end
 
-  @spec vehicles_by_stop_id() :: [{String.t, %{required(String.t) => [Proto.vehicle_position]}}]
-  defp vehicles_by_stop_id do
-    Enum.map(State.vehicles(), fn {comment, vehicles} ->
+  @spec vehicles_by_stop_id(term) :: [{String.t, %{required(String.t) => [Proto.vehicle_position]}}]
+  defp vehicles_by_stop_id(group) do
+    Enum.map(State.vehicles(group), fn {comment, vehicles} ->
       vehicles_by_stop = Enum.reduce(vehicles, %{}, fn v, acc ->
         update_in acc, [v.stop_id], fn vs ->
           [v | (vs || [])]

--- a/test/gtfs_realtime_viz_test.exs
+++ b/test/gtfs_realtime_viz_test.exs
@@ -34,8 +34,8 @@ defmodule GTFSRealtimeVizTest do
 
     raw = Proto.FeedMessage.encode(data)
 
-    GTFSRealtimeViz.new_message(raw, "this is the test data")
-    viz = GTFSRealtimeViz.visualize()
+    GTFSRealtimeViz.new_message(:test, raw, "this is the test data")
+    viz = GTFSRealtimeViz.visualize(:test)
 
     assert viz =~ "this is the test data"
     assert viz =~ "this_is_the_vehicle_id"


### PR DESCRIPTION
For instance, if you want this GenServer to support live viewing of prod, staging, and test data, without them crossing paths.