### PR TITLE
Add links to package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GTFSRealtimeViz.Mixfile do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [
@@ -47,6 +47,7 @@ defmodule GTFSRealtimeViz.Mixfile do
   defp package do
     [
       licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/mbta/gtfs_realtime_viz"},
       maintainers: ["Gabe Durazo <gabe@durazo.us>", "John Kohler", "Alex Sghia-Hughes", "Dave Maltzan"]
     ]
   end


### PR DESCRIPTION
The guide I read said the links were optional, but when I tried to build the hex package, it complained and said they were missing.