### PR TITLE
use label instead of id

### DIFF
--- a/lib/gtfs_realtime_viz.ex
+++ b/lib/gtfs_realtime_viz.ex
@@ -98,7 +98,7 @@ defmodule GTFSRealtimeViz do
   defp trainify(vehicles, status, ascii_train) do
     vehicles
     |> vehicles_with_status(status)
-    |> Enum.map(& "#{ascii_train} (#{&1.vehicle && &1.vehicle.id})")
+    |> Enum.map(& "#{ascii_train} (#{&1.vehicle && &1.vehicle.label})")
     |> Enum.join(",")
   end
 


### PR DESCRIPTION
The vehicle ID is basically useless for visualization, especially when you are trying to compare to other data sources, because it is internal to RTR only. Using the vehicle label allows us to compare to what's on the OCC Green Line page or what we see in real life.