### PR TITLE
use direction ID to distinguish the same stop

### DIFF
--- a/lib/templates/diff.eex
+++ b/lib/templates/diff.eex
@@ -21,6 +21,8 @@
         </tr>
 
         <%= for {stop_name, stop_id_0, stop_id_1} <- stops do %>
+          <% stop_id_0 = {stop_id_0, 0} %>
+          <% stop_id_1 = {stop_id_1, 1} %>
           <% vs0_base = by_stop_base[stop_id_0] || [] %>
           <% vs1_base = by_stop_base[stop_id_1] || [] %>
           <% base_trips_0 = trip_update_base[stop_id_0] || [] %>

--- a/lib/templates/single_file.eex
+++ b/lib/templates/single_file.eex
@@ -21,6 +21,8 @@
         </tr>
 
         <%= for {stop_name, stop_id_0, stop_id_1} <- stops do %>
+          <% stop_id_0 = {stop_id_0, 0} %>
+          <% stop_id_1 = {stop_id_1, 1} %>
           <% vs0 = vehicles_by_stop[stop_id_0] || [] %>
           <% vs1 = vehicles_by_stop[stop_id_1] || [] %>
           <tr>
@@ -99,4 +101,3 @@
 
   </div>
 <% end %>
-


### PR DESCRIPTION
By including the direction ID as a part of the stop, we can distinguish vehicles going different directions at the same stop ID.

Downsides: vehicles without a direction ID (shuttles?) won't appear.