### PR TITLE
sort trips by time

### DIFF
--- a/lib/gtfs_realtime_viz.ex
+++ b/lib/gtfs_realtime_viz.ex
@@ -154,9 +154,17 @@ defmodule GTFSRealtimeViz do
   end
   def format_times(time_list) do
     time_list
-    |> Enum.sort()
+    |> sort_by_time()
     |> Enum.take(2)
     |> Enum.map(&format_time/1)
+  end
+
+  def sort_by_time(time_list) do
+    Enum.sort(time_list, &time_list_sorter/2)
+  end
+
+  defp time_list_sorter({_, time1}, {_, time2}) do
+    Timex.before?(time1, time2)
   end
 
   defp format_time({_, nil}) do

--- a/test/gtfs_realtime_viz_test.exs
+++ b/test/gtfs_realtime_viz_test.exs
@@ -645,4 +645,12 @@ defmodule GTFSRealtimeVizTest do
       assert GTFSRealtimeViz.trips_we_care_about(state, routes_we_care_about) == expected
     end
   end
+
+  describe "sort_by_time/1" do
+    test "sorts the time list by time" do
+      time_list = [{"12345", ~D[2018-01-03]}, {"12345", ~D[2018-01-02]}, {"11111", ~D[2018-01-01]}, {"11112", ~D[2018-01-05]}]
+      result = GTFSRealtimeViz.sort_by_time(time_list)
+      assert List.first(result) == {"11111", ~D[2018-01-01]}
+    end
+  end
 end


### PR DESCRIPTION
tested locally on the dashboard compared to the live dashboard on dev.  a trip with a later predictoin but an added trip id on the live one was sorted before a more current prediction whereas locally it was sorted correctly by time.

![screen shot 2018-01-18 at 3 34 19 pm](https://user-images.githubusercontent.com/2266961/35120138-304faa6c-fc65-11e7-9abb-4b6e7eea0fcb.png)
![screen shot 2018-01-18 at 3 34 59 pm](https://user-images.githubusercontent.com/2266961/35120139-30626472-fc65-11e7-9349-bd246aaa30b2.png)
