### PR TITLE
sort diff correctly independently and then merge together

### DIFF
--- a/lib/gtfs_realtime_viz.ex
+++ b/lib/gtfs_realtime_viz.ex
@@ -191,28 +191,20 @@ defmodule GTFSRealtimeViz do
     formatted_predictions = for {{base_trip, base_prediction}, {diff_trip, diff_prediction}} <- sort_time_diff(base_list, diff_list) do
       {format_time({base_trip, base_prediction}), format_time({diff_trip, diff_prediction})}
     end
-    Enum.take(formatted_predictions, 2)
   end
 
   def sort_time_diff(base_list, diff_list) do
-    predictions = for {base, diff} <- zip_pad(sort_by_time(base_list), sort_by_time(diff_list), [])  do
+    for {base, diff} <- zip_pad(sort_by_time(base_list), sort_by_time(diff_list), 2, [])  do
       {base, diff}
     end
-    Enum.take(predictions, 2)
   end
 
-  defp zip_pad([], [], zipped) do
-    Enum.reverse(zipped)
-  end
-  defp zip_pad([base_head | base_tail], [], zipped) do
-    zip_pad(base_tail, [], [{base_head, nil} | zipped])
-  end
-  defp zip_pad([], [diff_head | diff_tail], zipped) do
-    zip_pad([], diff_tail, [{nil, diff_head} | zipped])
-  end
-  defp zip_pad([base_head | base_tail], [diff_head | diff_tail], zipped) do
-    zip_pad(base_tail, diff_tail, [{base_head, diff_head} | zipped])
-  end
+  defp zip_pad(base_list, diff_list, count, acc)
+  defp zip_pad([], [], _, acc), do: Enum.reverse(acc)
+  defp zip_pad(_, _, 0, acc), do: Enum.reverse(acc)
+  defp zip_pad([], [head | tail], count, acc), do: zip_pad([], tail, count - 1, [{nil, head} | acc])
+  defp zip_pad([head | tail], [], count, acc), do: zip_pad(tail, [], count - 1, [{head, nil} | acc])
+  defp zip_pad([base_head | base_tail], [diff_head | diff_tail], count, acc), do: zip_pad(base_tail, diff_tail, count - 1, [{base_head, diff_head} | acc])
 
   @spec trainify([Proto.vehicle_position], Proto.vehicle_position_statuses, String.t) :: iodata
   defp trainify(vehicles, status, ascii_train) do

--- a/test/gtfs_realtime_viz_test.exs
+++ b/test/gtfs_realtime_viz_test.exs
@@ -653,4 +653,22 @@ defmodule GTFSRealtimeVizTest do
       assert List.first(result) == {"11111", ~D[2018-01-01]}
     end
   end
+
+  describe "sort_time_diff/2" do
+    test "sorts all predictions by time" do
+      base_list = [{"12345", ~D[2018-01-03]}, {"12345", ~D[2018-01-02]}, {"11111", ~D[2018-01-01]}, {"11112", ~D[2018-01-05]}]
+      diff_list = [{"54321", ~D[2018-02-03]}, {"15243", ~D[2018-02-02]}, {"22222", ~D[2018-02-01]}, {"21111", ~D[2018-02-05]}]
+
+      result = GTFSRealtimeViz.sort_time_diff(base_list, diff_list)
+      assert List.first(result) == {{"11111", ~D[2018-01-01]}, {"22222", ~D[2018-02-01]}}
+    end
+
+    test "always gives two results per environment if it has two or more" do
+      base_list = [{"12345", ~D[2018-01-03]}, {"12345", ~D[2018-01-02]}, {"11111", ~D[2018-01-01]}, {"11112", ~D[2018-01-05]}]
+      diff_list = [{"54321", ~D[2018-02-03]}]
+
+      result = GTFSRealtimeViz.sort_time_diff(base_list, diff_list)
+      assert result == [{{"11111", ~D[2018-01-01]}, {"54321", ~D[2018-02-03]}}, {{"12345", ~D[2018-01-02]}, nil}]
+    end
+  end
 end


### PR DESCRIPTION
previously the behavior was to merge the two sets we were diffing and then take trips out based on shared trip id.  the problem with this is that trip id is not really meaningful between environments, so we were matching incorrect trips together.  

new behavior is get the lists from both environments, sort them on their own and then merge them at that point.  we then take the first two pairs of results and show that.