### PR TITLE
dont show routes that dont have stops in output

### DIFF
--- a/lib/gtfs_realtime_viz.ex
+++ b/lib/gtfs_realtime_viz.ex
@@ -47,9 +47,10 @@ defmodule GTFSRealtimeViz do
   @spec visualize(term, route_opts) :: String.t
   def visualize(group, opts) do
     routes = Map.keys(opts[:routes])
+    display_routes = opts[:routes] |> Enum.reject(fn {key, val} -> val == [] end) |> Map.new
     vehicle_archive = get_vehicle_archive(group, routes)
     trip_update_archive = get_trip_update_archive(group, routes, opts[:timezone])
-    [trip_update_archive: trip_update_archive, vehicle_archive: vehicle_archive, routes: opts[:routes], render_diff?: false]
+    [trip_update_archive: trip_update_archive, vehicle_archive: vehicle_archive, routes: display_routes, render_diff?: false]
     |> gen_html
     |> Phoenix.HTML.safe_to_string
   end


### PR DESCRIPTION
should facilitate showing a green shared route on the dashboard.