### PR TITLE
put vehicle ids with nil stop ids up at the top when they exist

### DIFF
--- a/lib/templates/single_file.eex
+++ b/lib/templates/single_file.eex
@@ -4,6 +4,25 @@
     <div class="viz-comment"><%= comment %></div>
 
     <h2>Routes</h2>
+    <% nil_stops_0 = {nil, 0} %>
+    <% nil_stops_1 = {nil, 1} %>
+    <% ns0 = vehicles_by_stop[nil_stops_0] || [] %>
+    <% ns1 = vehicles_by_stop[nil_stops_1] || [] %>
+    <%= if ns0 != [] or ns1 != [] do %>
+      <table>
+        No Stop ID:
+        <%= for ns <- ns0 do %>
+          <tr>
+            <%= ns.vehicle.id %>
+          </tr>
+        <% end %>
+        <%= for ns <- ns1 do %>
+          <tr>
+            <%= ns.vehicle.id %>
+          </tr>
+        <% end %>
+      </table>
+    <% end %>
 
     <%= for {route_name, stops} <- @routes do %>
       <h3><%= route_name %></h3>

--- a/lib/templates/single_file.eex
+++ b/lib/templates/single_file.eex
@@ -8,7 +8,8 @@
     <% nil_stops_1 = {nil, 1} %>
     <% ns0 = vehicles_by_stop[nil_stops_0] || [] %>
     <% ns1 = vehicles_by_stop[nil_stops_1] || [] %>
-    <% Map.delete(vehicles_by_stop, nil) %>
+    <% non_nil_vehicles = Map.delete(vehicles_by_stop, nil_stops_0) %>
+    <% non_nil_vehicles = Map.delete(non_nil_vehicles, nil_stops_1) %>
     <%= if ns0 != [] or ns1 != [] do %>
       <table>
         No Stop ID:
@@ -39,8 +40,8 @@
         <%= for {stop_name, stop_id_0, stop_id_1} <- stops do %>
           <% stop_id_0 = {stop_id_0, 0} %>
           <% stop_id_1 = {stop_id_1, 1} %>
-          <% vs0 = vehicles_by_stop[stop_id_0] || [] %>
-          <% vs1 = vehicles_by_stop[stop_id_1] || [] %>
+          <% vs0 = non_nil_vehicles[stop_id_0] || [] %>
+          <% vs1 = non_nil_vehicles[stop_id_1] || [] %>
           <tr>
             <td>
               <%= for prediction <- format_times(trip_updates[stop_id_0]) do %>

--- a/lib/templates/single_file.eex
+++ b/lib/templates/single_file.eex
@@ -8,6 +8,7 @@
     <% nil_stops_1 = {nil, 1} %>
     <% ns0 = vehicles_by_stop[nil_stops_0] || [] %>
     <% ns1 = vehicles_by_stop[nil_stops_1] || [] %>
+    <% Map.delete(vehicles_by_stop, nil) %>
     <%= if ns0 != [] or ns1 != [] do %>
       <table>
         No Stop ID:

--- a/test/gtfs_realtime_viz_test.exs
+++ b/test/gtfs_realtime_viz_test.exs
@@ -4,6 +4,82 @@ defmodule GTFSRealtimeVizTest do
   alias GTFSRealtimeViz.Proto
   alias Test.DataHelpers
 
+  test "when all vehicles have stop ids, does not have a no stop id section" do
+    data = %Proto.FeedMessage{
+      header: %Proto.FeedHeader{
+        gtfs_realtime_version: "1.0",
+      },
+      entity: [
+        %Proto.FeedEntity{
+          id: "123",
+          is_deleted: false,
+          vehicle: %Proto.VehiclePosition{
+            trip: %Proto.TripDescriptor{
+              trip_id: "this_is_the_trip_id",
+              route_id: "route",
+              direction_id: 0,
+            },
+            vehicle: %Proto.VehicleDescriptor{
+              id: "this_is_the_vehicle_id",
+              label: "this_is_the_vehicle_label",
+            },
+            position: %Proto.Position{
+              latitude: 0.00,
+              longitude: 0.00,
+            },
+            stop_id: "this_is_the_stop_id",
+          }
+        }
+      ]
+    }
+
+    raw = Proto.FeedMessage.encode(data)
+
+    GTFSRealtimeViz.new_message(:test, raw, "this is the test data")
+    viz = GTFSRealtimeViz.visualize(:test, %{routes: %{"route" => [{"stop", "this_is_the_stop_id", "outbound"}]}})
+
+    refute viz =~ "No Stop ID:"
+    assert viz =~ "this_is_the_vehicle_id"
+  end
+
+  test "when the prediction does not have a stop id, puts the vehicle in a separate location" do
+    data = %Proto.FeedMessage{
+      header: %Proto.FeedHeader{
+        gtfs_realtime_version: "1.0",
+      },
+      entity: [
+        %Proto.FeedEntity{
+          id: "123",
+          is_deleted: false,
+          vehicle: %Proto.VehiclePosition{
+            trip: %Proto.TripDescriptor{
+              trip_id: "this_is_the_trip_id",
+              route_id: "route",
+              direction_id: 0,
+            },
+            vehicle: %Proto.VehicleDescriptor{
+              id: "this_is_the_vehicle_id",
+              label: "this_is_the_vehicle_label",
+            },
+            position: %Proto.Position{
+              latitude: 0.00,
+              longitude: 0.00,
+            },
+            stop_id: nil,
+          }
+        }
+      ]
+    }
+
+    raw = Proto.FeedMessage.encode(data)
+
+    GTFSRealtimeViz.new_message(:nil_test, raw, "this is the test data")
+    viz = GTFSRealtimeViz.visualize(:nil_test, %{routes: %{"route" => [{"stop", "this_is_the_stop_id", "outbound"}]}})
+
+    assert viz =~ "No Stop ID:"
+    assert viz =~ "this_is_the_vehicle_id"
+  end
+
   test "visualizes a file" do
     data = %Proto.FeedMessage{
       header: %Proto.FeedHeader{


### PR DESCRIPTION
[[2] Dashboard bug: a train with no stop_id in VehiclePositions gets put at a random stop on the dashboard](https://app.asana.com/0/584764604969369/1118432307417888)

im sure theres a cleaner way to express this in the template